### PR TITLE
Add the command to install the Draft-dxf-importer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:bionic
 RUN apt-get update -y
 # Timezone configuration is required to avoid tzdata interuption while installing packages.
-ENV TZ=Asia/Jakarta
+ENV TZ=Asia/Tokyo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get -y install software-properties-common build-essential python-dev python-pip git unzip
+RUN apt-get -y install software-properties-common build-essential python-dev python-pip git unzip wget
 RUN add-apt-repository ppa:freecad-maintainers/freecad-daily
 RUN apt-get update -y
 RUN apt install -y freecad
 COPY . .
 RUN pip install -r requirements.txt
+RUN mkdir /root/.FreeCAD && wget https://github.com/yorikvanhavre/Draft-dxf-importer/archive/1.39.zip && unzip 1.39.zip && cp Draft-dxf-importer-1.39/* /root/.FreeCAD/
 CMD [ "./kb_builder.py" ]


### PR DESCRIPTION
## What is This

This pull request adds the command into the Dockerfile to install Draft-dxf-importer at the same time of building the Docker image.

## Why is this pull request needed

By the current your pull request, we will be able to build the docker image of the kb_builder. I strongly want to say thank you.

My motivation of using the kb_builder is to generate a DXF file. However, the current Dockerfile doesn't have the command to install the Draft-dxf-importer. Therefore, we can't generate and download any DXF file. I want to solve this issue, and I want to add the command to install the Draft-dxf-importer tool at the same time of building the Docker image.